### PR TITLE
Added other os support (like Windows)

### DIFF
--- a/src/main/java/com/googlecode/pngtastic/PngtasticLayerer.java
+++ b/src/main/java/com/googlecode/pngtastic/PngtasticLayerer.java
@@ -6,6 +6,7 @@ import com.googlecode.pngtastic.core.PngLayerer;
 import com.googlecode.pngtastic.core.PngOptimizer;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,7 +46,7 @@ public class PngtasticLayerer {
 			final ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
 			baseImage.writeDataOutputStream(outputBytes);
 
-			final String file = toDir + "/" + outFile;
+			final String file = toDir + File.separator + outFile;
 			baseImage.setFileName(file);
 			baseImage.export(file, outputBytes.toByteArray());
 

--- a/src/main/java/com/googlecode/pngtastic/PngtasticOptimizer.java
+++ b/src/main/java/com/googlecode/pngtastic/PngtasticOptimizer.java
@@ -42,8 +42,8 @@ public class PngtasticOptimizer {
 
 		for (String file : fileNames) {
 			try {
-				String outputPath = toDir + "/" + file;
-				makeDirs(outputPath.substring(0, outputPath.lastIndexOf('/')));
+				String outputPath = toDir + File.separator + file;
+				makeDirs(outputPath.substring(0, outputPath.lastIndexOf(File.separator)));
 
 				PngImage image = new PngImage(file, logLevel);
 				optimizer.optimize(image, outputPath + fileSuffix, removeGamma, compressionLevel);

--- a/src/main/java/com/googlecode/pngtastic/ant/PngOptimizerTask.java
+++ b/src/main/java/com/googlecode/pngtastic/ant/PngOptimizerTask.java
@@ -77,14 +77,14 @@ public class PngOptimizerTask extends Task {
 		for (FileSet fileset : filesets) {
 			DirectoryScanner ds = fileset.getDirectoryScanner(getProject());
 			for (String src : ds.getIncludedFiles()) {
-				String inputPath = fileset.getDir() + "/" + src;
+				String inputPath = fileset.getDir() + File.separator + src;
 				String outputPath;
 				try {
 					String outputDir = (toDir == null) ? fileset.getDir().getCanonicalPath() : toDir;
-					outputPath = outputDir + "/" + src;
+					outputPath = outputDir + File.separator + src;
 
 					// make the directory this file is in (for nested dirs in a **/* fileset)
-					makeDirs(outputPath.substring(0, outputPath.lastIndexOf('/')));
+					makeDirs(outputPath.substring(0, outputPath.lastIndexOf(File.separator)));
 
 					PngImage image = new PngImage(inputPath, logLevel);
 					optimizer.optimize(image, outputPath + fileSuffix, removeGamma, compressionLevel);

--- a/src/main/java/com/googlecode/pngtastic/core/PngOptimizer.java
+++ b/src/main/java/com/googlecode/pngtastic/core/PngOptimizer.java
@@ -234,7 +234,7 @@ public class PngOptimizer extends PngProcessor {
 	 * Get the css containing data uris of the images processed by the optimizer
 	 */
 	public void generateDataUriCss(String dir) throws IOException {
-		final String path = (dir == null) ? "" : dir + "/";
+		final String path = (dir == null) ? "" : dir + File.separator;
 		final PrintWriter out = new PrintWriter(path + "DataUriCss.html");
 
 		try {


### PR DESCRIPTION
When using the java classes with ab IDE on windows, the app crashes
this is because file path separator where hardcodded in favor of linux and macos
Now, the app uses File.separator instead of '/' or "/"
This fixed all my windows issues